### PR TITLE
fix: pin ejabberd/mix to specific tag (OS-4014)

### DIFF
--- a/ecs/Dockerfile
+++ b/ecs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ejabberd/mix as builder
+FROM ejabberd/mix:19.02 as builder
 ARG VERSION
 ENV VERSION=${VERSION:-latest} \
     MIX_ENV=prod


### PR DESCRIPTION
Potential fix for build error on the pipeline (https://buildkite.com/improbable/platform-build-public-docker/builds/75#3a247f08-8723-44c8-ace7-b4e438ed9700/256-579) since the builder image was updated just 16 days ago with a new latest tag.

Couldn't reproduce the issue locally though so must try this on the pipeline to be sure. Even if it's not the fix, it's good practise to pin images so worth doing anyway.